### PR TITLE
Added support for running STAR in parallel threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "face-detection-tflite",  # for face-alignment
     "pytorch3d@git+https://github.com/facebookresearch/pytorch3d.git",
     "dearpygui",
+    "joblib"
 ]
 authors = [
   {name = "Shenhan Qian", email = "shenhan.qian@tum.de"},

--- a/vhap/config/base.py
+++ b/vhap/config/base.py
@@ -54,6 +54,7 @@ class DataConfig(Config):
     use_alpha_map: bool = False
     use_landmark: bool = True
     landmark_source: Optional[Literal['face-alignment', 'star']] = "star"
+    star_landmark_detector_n_jobs: int = 32
 
 
 @dataclass()

--- a/vhap/model/tracker.py
+++ b/vhap/model/tracker.py
@@ -1387,15 +1387,17 @@ class GlobalTracker(FlameTracker):
                 detector = LandmarkDetectorFA()
                 detector.annotate_landmarks(dataloader, add_iris=False)
         elif cfg.data.landmark_source == 'star':
-            from vhap.util.landmark_detector_star import LandmarkDetectorSTAR
+            from vhap.util.landmark_detector_star import LandmarkDetectorSTAR, STAR_detect_dataset_parallel
             
             if not cfg.exp.reuse_landmarks or not dataset.get_property_path("landmark2d/STAR", -1).exists():
                 # LandmarkDetector only supports a batch_size of 1
                 dataloader = DataLoader(dataset, batch_size=1, shuffle=False, num_workers=4)
 
                 os.umask(0o002)
-                detector = LandmarkDetectorSTAR()
-                detector.annotate_landmarks(dataloader)
+                # detector = LandmarkDetectorSTAR()
+                # detector.annotate_landmarks(dataloader)
+
+                STAR_detect_dataset_parallel(dataset, n_jobs=cfg.data.star_landmark_detector_n_jobs)
         else:
             raise ValueError(f"Unknown landmark source: {cfg.data.landmark_source}")
     


### PR DESCRIPTION
Hey Shenhan!

I've added some capability in `landmark_detector_star.py` file that allows the landmark detector to process the whole sequence much faster, using parallel threads via `joblib` library. 
I've been experiencing some time bottleneck at the landmark estimation stage when the total number of images is in the scale of thousands (e.g. for the standard Nersemble capture: smth between 500 and 3000 images). STAR would take several hours on my end in this case. 
The new implementation creates `n_jobs` `LandmarkDetectorSTAR()` objects and gives a fair share of the images to each worker. E.g. setting 32 jobs lowers the overall time for a single Nersemble from 3 hours to 5 minutes on my end.

I've also added `joblib` requirement to the project dependencies for this reason (easily pip-installable).

Artem