### PR TITLE
Added the correct colour-science dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pillow",
     "opencv-python",
     "ffmpeg-python",
-    "colour",
+    "colour-science",
     "torch",  # manually install to avoid CUDA version mismatch
     "torchvision",  # manually install to avoid CUDA version mismatch
     "tensorboard",


### PR DESCRIPTION
The `colour` dependency currently referenced in the `pyproject.toml` is not the intended package.  
The correct package is https://github.com/colour-science/colour instead of https://github.com/vaab/colour.

This change fixes `util/color_correction.py` and `data/nersemble_v2_dataset.py`.